### PR TITLE
Fix: removed non-existent ui/fonts directory from CMakeLists.txt

### DIFF
--- a/examples/ESP-IDF/DX48480021ET-WB-A-LVGL/main/CMakeLists.txt
+++ b/examples/ESP-IDF/DX48480021ET-WB-A-LVGL/main/CMakeLists.txt
@@ -1,10 +1,8 @@
 idf_component_register(SRC_DIRS
                     "." 
                     "ui/components"
-                    "ui/fonts"
                     "ui/images"
                     "ui/screens"
                     "ui"
-                    "ui/fonts"
                     INCLUDE_DIRS
                     ".")


### PR DESCRIPTION
There was a bug on .\examples\esp-idf\main\CMakeLists.txt and there was ui/fonts that was leading to error in compilation. It has been fixed now. 